### PR TITLE
Fix project URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
         "jupyterlab",
         "jupyterlab-extension"
     ],
-    "homepage": "https://github.com/gmwcraig/astronbs",
+    "homepage": "https://github.com/mwcraig/astronbs",
     "bugs": {
-        "url": "https://github.com/gmwcraig/astronbs/issues"
+        "url": "https://github.com/mwcraig/astronbs/issues"
     },
     "license": "BSD-3-Clause",
     "author": {
@@ -26,7 +26,7 @@
     "style": "style/index.css",
     "repository": {
         "type": "git",
-        "url": "https://github.com/gmwcraig/astronbs.git"
+        "url": "https://github.com/mwcraig/astronbs.git"
     },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
This may be the funniest bug I had to debug.

I've been bugged for quite some time in JupyterLab with a 404 error on `gmwcraig.png`, without understanding where it could come from.

Today I figured that it was probably due to the JupyterLab PyPi manager UI that was trying to suggest to install astronb, and trying to show your Github account profile picture, from the URL defined in this repo.

I can also see one mention of this error in the Jupyter discourse: https://discourse.jupyter.org/search?q=gmwcraig

![Screenshot from 2024-05-17 14-17-32](https://github.com/mwcraig/astronbs/assets/21197331/90f5469a-e428-48aa-b2b1-4b30a2088417)
